### PR TITLE
Update en_AU.all.json

### DIFF
--- a/local/site/en_AU.all.json
+++ b/local/site/en_AU.all.json
@@ -1,5 +1,6 @@
 {
   "site_owner": { "other": "ABC Cinemas" },
+  "nav_homepage": { "other": "ABC Cinemas" },
   "settings_title": { "other": "Settings" },
   "powered_by_name": { "other": "Shift72" },
   "powered_by_url": { "other": "https://www.shift72.com" }


### PR DESCRIPTION
- `nav_homepage` needs to be an entry in our local/en_AU.all.json to customise, otherwise nav logos are plastered on top of 'ABC Cinemas'

![Screen Shot 2020-06-18 at 2 17 06 PM](https://user-images.githubusercontent.com/3870133/84970269-6eb38880-b16e-11ea-8ab3-dc4cd523dd85.png)
