### PR TITLE
Enforce the usage of local kibble languages, and never use core version

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ If not, use the logo as a base and either personal skill or an online generator 
 ### kibble.json changes
 - Change the `name` property to match the name of the site. It should be less than 20 characters long, and does not need to contain the word "template"
 - Change the `siteUrl` property to point to the production site url, so your local development environment will use the films created there.
+- Set the correct defaultLanguage and languages for the particular site.
+  - Don't add all the languages from core/kibble.json, as this will cause unnecassary load when rendering.
+  - Dont delete these values from local/kibble.json as this will cause the site to use the values from core/kibble.json, as this will cause unnecassary load when rendering.
 
 ### language strings
 - Change the `site_owner` property to be the name of the site/client. This is at least used on the footer for the copyright notice.

--- a/local/kibble.json
+++ b/local/kibble.json
@@ -1,5 +1,9 @@
 {
   "name": "shift72-template",
   "version": "0.0.1",
-  "siteUrl": "https://abccinemas.screenplus.co"
+  "siteUrl": "https://abccinemas.screenplus.co",
+  "defaultLanguage": "en",
+  "languages": {
+    "en": "en_AU"
+  },
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "css:watch:local": "npm-run-all --parallel css:watch:local:variables css:watch:local:custom",
     "css:watch:local:variables": "chokidar local/site/styles/_variables.scss -c 'npm run css:local:variables'",
     "css:watch:local:custom": "chokidar local/site/styles/*.scss -i local/site/styles/_variables.scss -c 'npm run css:local:custom'",
-    "merge:json:kibble": "node tools/merge-json.js output/kibble.json core/kibble.json local/kibble.json",
+    "merge:json:kibble": "node tools/merge-json.js output/kibble.json core/kibble.json local/kibble.json 'defaultLanguage,languages'",
     "merge:json:lang": "for file in local/site/*_*.all.json; do filename=$(echo $file | grep -Eo '[^/]+$'); node tools/merge-json.js output/site/$filename core/site/$filename local/site/$filename; done",
     "json:kibble:lang:watch": "chokidar local/site/en_AU.all.json -c 'npm run merge:json:lang'"
   },

--- a/tools/merge-json.js
+++ b/tools/merge-json.js
@@ -11,9 +11,10 @@ log = function(message) {
   console.log(chalk.green.bold(message));
 }
 
-var outputFile = process.argv[2];
-var masterFile = process.argv[3];
-var localFile  = process.argv[4];
+var outputFile          = process.argv[2];
+var masterFile          = process.argv[3];
+var localFile           = process.argv[4];
+const ignoredProperties = (process.argv[5] || '').split(',');
 
 if(!fs.existsSync(masterFile)) {
   bail('Core file doesn\'t exist: ' + masterFile);
@@ -37,7 +38,13 @@ else {
   }
 }
 
-var result = merge(masterObject, localObject);
+var result = merge(masterObject, localObject, {
+  customMerge: key => {
+    if (ignoredProperties.includes(key)){
+      return (a, b) => b;
+    }
+  }
+});
 
 fs.writeFile(outputFile, JSON.stringify(result, null, 4), function(error) {
   if(error) {


### PR DESCRIPTION
Something will also need to be done about the dozens of existing templates needlessly creating different language versions.