### PR TITLE
Update nsprc

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,9 +1,4 @@
 {
-  "1002401": {
-    "active": true,
-    "notes": "Ignored because there is no patched version available",
-    "expiry": "01/01/2022, 00:00:00"
-  },
   "1004946": {
     "active": true,
     "notes": "Ignored because there is no patched version available",

--- a/.nsprc
+++ b/.nsprc
@@ -3,5 +3,10 @@
     "active": true,
     "notes": "Ignored because there is no patched version available",
     "expiry": "01/01/2022, 00:00:00"
+  },
+  "1004946": {
+    "active": true,
+    "notes": "Ignored because there is no patched version available",
+    "expiry": "01/01/2022, 00:00:00"
   }
 }


### PR DESCRIPTION
I get this output when I run `npm i` on my machine:
`1 of the excluded vulnerabilities did not match any of the found vulnerabilities: 1002401. It can be removed from the .nsprc file or --exclude -x flags.
1 vulnerabilities found. Node security advisories: 1004946`
So I have changed the .nsprc file.

Can you check whether you get this same error on your machine?