### PR TITLE
publish -> deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "npm run init && npm-run-all --parallel js:watch js:watch:local css:watch kibble:watch kibble:watch:local json:kibble:lang:watch",
     "init": "node tools/build-output.js --mode=init && npm-run-all css js merge:json:kibble merge:json:lang",
     "build": "npm run kibble:build",
-    "publish": "npm run build && cd output && kibble publish",
+    "publish": "echo \"Deprecated, use 'npm run deploy'\".",
+    "deploy": "npm run build && cd output && kibble publish",
 
     "js": "rollup -c",
     "js:watch": "chokidar ./output/site/static/js/*.js --throttle 300 -c 'npm run js'",


### PR DESCRIPTION
This changes the internal command to deploy the site from `npm run publish` to `npm run deploy` to avoid confusion with the built-in command `npm publish` which instead attempts to publish your code as an NPM package on the NPM registry. For new people it's quite easy to forget the `run` part (especially since `npm start` doesn't have it), and because the built-in command will respond with some errors, it's also easy to be confused by the result and cause support issues.

- [ ] Update wiki after merging.