### PR TITLE
support css variables

### DIFF
--- a/local/site/styles/_variables.css
+++ b/local/site/styles/_variables.css
@@ -1,0 +1,11 @@
+/*
+
+  CSS variable overrides go in this file.
+
+  e.g.
+
+  :root {
+    --primary-rgb: 255, 0, 0;
+  }
+
+*/

--- a/tools/css.js
+++ b/tools/css.js
@@ -15,6 +15,8 @@ let log = message => {
 fse.ensureDirSync('./output/site/styles/local');
 fse.copySync('./local/site/styles', './output/site/styles/local');
 
+fse.ensureFileSync('./output/site/styles/local/_variables.css');
+
 // concat core and local variables files
 let localSassVars = fse.readFileSync('./output/site/styles/local/_variables.scss');
 let localCssVars = fse.readFileSync('./output/site/styles/local/_variables.css');

--- a/tools/css.js
+++ b/tools/css.js
@@ -16,9 +16,10 @@ fse.ensureDirSync('./output/site/styles/local');
 fse.copySync('./local/site/styles', './output/site/styles/local');
 
 // concat core and local variables files
-let localVars = fse.readFileSync('./output/site/styles/local/_variables.scss');
+let localSassVars = fse.readFileSync('./output/site/styles/local/_variables.scss');
+let localCssVars = fse.readFileSync('./output/site/styles/local/_variables.css');
 let coreVars = fse.readFileSync('./node_modules/@shift72/core-template/site/styles/_variables.scss');
-fse.writeFileSync('./output/site/styles/_variables.scss', [localVars, coreVars].join('\n'));
+fse.writeFileSync('./output/site/styles/_variables.scss', [localSassVars, coreVars, localCssVars].join('\n'));
 
 // do sass
 let result = sass.renderSync({


### PR DESCRIPTION
Bit of a hack but I don't have a better idea.

When you run the site, you local variables file and core variables file are combined into one file in the output before Sass runs.  In order for the Sass variable overrides to work, your local variables need to be written to the output _before_ the core variables because of the way the `!default` flag works.  This is the opposite to how the CSS variables work... overrides must come after defaults.  However, the core variables file also has an `@use` statement at the top which causes a Sass error if your local variables file has a `:root` object in it.  So to prevent errors while functioning the way we want it to, the output file needs to have your local Sass variables, followed by the core Sass variables, followed by your local CSS variables.  I've gone with the quickest and easiest solution which is to split local CSS variables into their own file separate from Sass variables and modified the script to add them to output in the correct order.

Anyone got any better ideas?